### PR TITLE
Remove the muiThemable import from BodyContainer and ResponsiveAppBar

### DIFF
--- a/src/BodyContainer.js
+++ b/src/BodyContainer.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { toggleDrawerOpen } from './actions/responsiveDrawer';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import isResponsiveAndOverBreackPoint from './utils/drawerHelper.js';
 
 class BodyContainer extends Component {

--- a/src/ResponsiveAppBar.js
+++ b/src/ResponsiveAppBar.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { toggleDrawerOpen } from './actions/responsiveDrawer';
-import muiThemeable from 'material-ui/styles/muiThemeable';
 import isResponsiveAndOverBreackPoint from './utils/drawerHelper.js';
 import AppBar from 'material-ui/AppBar';
 


### PR DESCRIPTION
The muiThemable import isn't used anywhere I can see, and prevents the component from being used with the `next` branch on `material-ui`.  This PR just removes the reference so it can be used.